### PR TITLE
Switched to latexmk

### DIFF
--- a/rcs_latexdiff/rcs_latexdiff.py
+++ b/rcs_latexdiff/rcs_latexdiff.py
@@ -61,7 +61,7 @@ def get_file(rcs, root_path, relative_path, commit, filename):
     return file_content
 
 
-def exec_diff(old_filename, new_filename, diff_filename):
+def exec_diff(old_filename, new_filename, diff_filename, latexdiff_args):
     """ Exec Latexdiff
 
         :param old_filename:

--- a/rcs_latexdiff/rcs_latexdiff.py
+++ b/rcs_latexdiff/rcs_latexdiff.py
@@ -91,22 +91,10 @@ def exec_pdflatex(tex_filename, src_path):
     starting_dir = os.getcwd()
     os.chdir(src_path)
     
-    def single_run():
-        run_command("pdflatex -interaction nonstopmode -output-directory {} {}".format(tex_path, tex_filename))
-    
     # Run pdflatex and bibtex a bunch of times
     try:
-        single_run()
-        single_run()
-        
-        if os.path.isfile(aux_filename):
-            run_command("bibtex %s" % tex_filename)
-            run_command("bibtex %s" % aux_filename)
-            
-        single_run()
-        single_run()
-        
-        logger.info("Ran pdflatex and bibtex.")
+        run_command("latexmk -pdf -output-directory={} {}".format(tex_path, tex_filename))
+        logger.info("Ran latexmk on {} outputting to {}".format(tex_filename, tex_path))
     except:
         logger.debug("Problem building pdf file.")
     
@@ -327,6 +315,8 @@ def main():
     # Make the pdf
     if args.makepdf:
         pdf_filename = exec_pdflatex(dst_filename, os.path.join(root_path, relative_path))
+    else:
+        pdf_filename = os.path.splitext(dst_filename)[0] + ".pdf"
         
     # Open the pdf
     if args.openpdf:


### PR DESCRIPTION
I just discovered latexmk which, among other things, automatically figures out how many times to call pdflatex and bibtex to get all of the references to actually show up properly...

These changes will check if latexmk is available (it was already installed on my ubuntu system before I found out about it -- will likely be installed on osx systems too, not sure about windows), use it if it is, or use the old exec_pdflatex if it is not.

For me, rcs-latexdiff is now properly displaying citations, as well as crossing them out etc when they have been changed.
