### PR TITLE
Enable rcs-latexdiff on windows7

### DIFF
--- a/rcs_latexdiff/rcs.py
+++ b/rcs_latexdiff/rcs.py
@@ -162,7 +162,7 @@ class SVN(RCS):
         # So we don't differentiate root and relative paths
 
         # Get the root path of the repository
-        root_path = os.path.dirname(filename)
+        root_path = os.path.dirname(os.path.abspath(filename))
 
         relative_path = ""
         filename = os.path.basename(filename)

--- a/rcs_latexdiff/rcs_latexdiff.py
+++ b/rcs_latexdiff/rcs_latexdiff.py
@@ -173,7 +173,7 @@ def open_pdf(pdf_filename):
         subprocess.Popen(('open', pdf_filename))
     elif os.name == 'nt':
         os_str = "Windows"
-        os.startfile(pdf_filename)
+        os.system("start "+pdf_filename)
     elif os.name == 'posix':
         os_str = "Linux"
         with open('/dev/null') as output:
@@ -322,7 +322,7 @@ def clean_output_files(files):
 
 def check_latexdiff():
     """ Check that latexdiff binary is in the PATH """
-    check_latexdiff = "which latexdiff"
+    check_latexdiff = ("where" if sys.platform == "win32" else "which") + " latexdiff"
     ret, output = run_command(check_latexdiff)
 
     # latexdiff tool not available ?


### PR DESCRIPTION
There were some issues with rcs-latexdiff on Windows 7, which are fixed by this Changes. I used it this way the last days and it worked fine, but please have a look on the code.
- root_path corrected, see [Stackoverflow discussion on dirname](http://stackoverflow.com/questions/7783308/os-path-dirname-file-returns-empty)
- find latexdiff on windows path: `which` doesn't work on windows, so a conditional check is added and uses `where` if the system is Windows
- `open_pdf` now uses the correct call

Todo: handle blank space in windows directories/(filenames?)
