### PR TITLE
New features to increase stability

### DIFF
--- a/rcs_latexdiff/rcs.py
+++ b/rcs_latexdiff/rcs.py
@@ -1,7 +1,9 @@
+from __future__ import print_function, absolute_import
+
 import os
 import logging
 
-from utils import run_command
+from .utils import run_command
 
 logger = logging.getLogger("rcs-latexdiff")
 

--- a/rcs_latexdiff/rcs.py
+++ b/rcs_latexdiff/rcs.py
@@ -163,7 +163,7 @@ class SVN(RCS):
         # So we don't differentiate root and relative paths
 
         # Get the root path of the repository
-        root_path = os.path.dirname(filename)
+        root_path = os.path.dirname(os.path.abspath(filename))
 
         relative_path = ""
         filename = os.path.basename(filename)

--- a/rcs_latexdiff/rcs_latexdiff.py
+++ b/rcs_latexdiff/rcs_latexdiff.py
@@ -1,3 +1,5 @@
+from __future__ import print_function, absolute_import
+
 import re
 import argparse
 import logging
@@ -7,8 +9,8 @@ import sys
 import subprocess
 import distutils.spawn
 
-from rcs import get_rcs_class
-from utils import run_command, write_file, remove_latex_comments
+from .rcs import get_rcs_class
+from .utils import run_command, write_file, remove_latex_comments
 
 
 logger = logging.getLogger("rcs-latexdiff")
@@ -346,7 +348,7 @@ def check_latexdiff():
 
     # latexdiff tool not available ?
     if ret:
-        print """latexdiff tool not found in PATH
+        print("""latexdiff tool not found in PATH
 Install it or correct your PATH
 
 You can install it as follows:
@@ -354,7 +356,7 @@ You can install it as follows:
         apt-get install latexdiff
     MacPorts (OS X):
         sudo port install latexdiff
-"""
+""")
         exit(1)
 
 

--- a/rcs_latexdiff/rcs_latexdiff.py
+++ b/rcs_latexdiff/rcs_latexdiff.py
@@ -117,7 +117,7 @@ def exec_latexmk(tex_filename, src_path):
 
     # Run pdflatex and bibtex a bunch of times
     try:
-        run_command("latexmk -pdf -output-directory={} {}".format(tex_path, tex_filename))
+        run_command("latexmk -pdf -interaction=nonstopmode -output-directory={} {}".format(tex_path, tex_filename))
         logger.info("Ran latexmk on {} outputting to {}".format(tex_filename, tex_path))
     except:
         logger.debug("Problem building pdf file.")
@@ -184,7 +184,7 @@ def open_pdf(pdf_filename):
         subprocess.Popen(('open', pdf_filename))
     elif os.name == 'nt':
         os_str = "Windows"
-        os.startfile(pdf_filename)
+        os.system("start "+pdf_filename)
     elif os.name == 'posix':
         os_str = "Linux"
         with open('/dev/null') as output:
@@ -341,7 +341,7 @@ def clean_output_files(files):
 
 def check_latexdiff():
     """ Check that latexdiff binary is in the PATH """
-    check_latexdiff = "which latexdiff"
+    check_latexdiff = ("where" if sys.platform == "win32" else "which") + " latexdiff"
     ret, output = run_command(check_latexdiff)
 
     # latexdiff tool not available ?

--- a/rcs_latexdiff/rcs_latexdiff.py
+++ b/rcs_latexdiff/rcs_latexdiff.py
@@ -277,8 +277,12 @@ EXAMPLE USAGE:
         help='Don\'t try to open the created pdf file.')
 
     parser.add_argument('--force-pdflatex', action='store_true',
-        dest='forcepdflatex',
+        dest='force_pdflatex',
         help='Use pdflatex even if latexmk is present.')
+
+    parser.add_argument('--exclude-section-titles', action='store_true',
+        dest='exclude_sections',
+        help='Tells latexdiff to exclude diffs inside sub/section titles, which sometimes cause latex build problems.')
 
     parser.add_argument('--utf8', action='store_true',
         dest='utf8',
@@ -387,7 +391,9 @@ def main():
         dst_filename = args.output
 
     # Gather arguments to pass through to latexdiff
-    latexdiff_args = '--exclude-textcmd="section,subsection" '
+    latexdiff_args = ''
+    if args.exclude_sections:
+        latexdiff_args += '--exclude-textcmd="section,subsection" '
     if args.utf8:
         latexdiff_args += '--encoding=utf8 '
 
@@ -396,11 +402,11 @@ def main():
 
     # Make the pdf
     if args.makepdf:
-        if has_latexmk() and not args.forcepdflatex:
+        if has_latexmk() and not args.force_pdflatex:
             logger.info("Proceeding with latexmk.")
             pdf_filename = exec_latexmk(dst_filename, os.path.join(root_path, relative_path))
         else:
-            if args.forcepdflatex:\
+            if args.force_pdflatex:
                 logger.info("latexmk found but you said not to use it...using pdflatex and bibtex")
             else:
                 logger.info("latexmk wasn't found...using pdflatex and bibtex")

--- a/rcs_latexdiff/rcs_latexdiff.py
+++ b/rcs_latexdiff/rcs_latexdiff.py
@@ -387,7 +387,7 @@ def main():
         dst_filename = args.output
 
     # Gather arguments to pass through to latexdiff
-    latexdiff_args = ''
+    latexdiff_args = '--exclude-textcmd="section,subsection" '
     if args.utf8:
         latexdiff_args += '--encoding=utf8 '
 

--- a/rcs_latexdiff/utils.py
+++ b/rcs_latexdiff/utils.py
@@ -1,3 +1,5 @@
+from __future__ import print_function, absolute_import
+
 import subprocess
 import logging
 import re
@@ -17,17 +19,17 @@ def run_command(command, path=""):
     try:
         # Forge command
         if path not in ['', '.']:
-            command = '(cd %s && %s)' % (path, command)
+            command = '(cd {} && {})'.format(path, command)
 
         logger.debug("Run command: %s" % (command))
         process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        output = process.communicate()[0]
+        output = process.communicate()[0].decode('utf-8')
         retcode = process.returncode
 
         logger.debug("Return code: %d" % (retcode))
         return retcode, output
 
-    except OSError, e:
+    except OSError as e:
         logger.info("Execution failed: %s" % (e))
         exit(1)
 


### PR DESCRIPTION
This PR adds a couple of things, let me know if you'd prefer separate PRs.

Three new options:

- `--force-pdflatex` forces it to use pdflatex even if latexmk is present
- `--exclude-section-titles` passes a flag to latexdiff to tell it to ignore changes to section titles; this can cause confusing problems sometimes
- `--repeat=number` causes the build process (either `latexmk` or `pdflatex+bibtex+pdflatex+pdflatex`) to run some specified number of times to allow references to converge

Also:

- Python 3 compatability (due to cgranade)
- nonstop inteaction mode on `latexmk` (due to JanBerling, also in separate compatible PR)
- Windows compatibility (due to JanBerling, also in separate compatible PR)