### PR TITLE
Fix unicode bug on utils.write_file

### DIFF
--- a/rcs_latexdiff/utils.py
+++ b/rcs_latexdiff/utils.py
@@ -41,6 +41,8 @@ def write_file(content, filename):
 
     """
     logger.debug("Writing content into %s" % filename)
+    if isinstance(content, unicode):
+        content = content.encode("utf-8")
     with open(filename, 'w') as f:
         f.write(content)
 


### PR DESCRIPTION
When content is of type unicode and contains unicode characters,
write_file has to encode the utf-8 characters. Otherwise, it throws an execption and does not work.