### PR TITLE
Remove the line break in comments-only lines

### DIFF
--- a/rcs_latexdiff/utils.py
+++ b/rcs_latexdiff/utils.py
@@ -45,5 +45,7 @@ def write_file(content, filename):
         f.write(content)
 
 def remove_latex_comments(content):
+    # If a line contains only a comment, remove the line completely
+    content = re.sub(r'^[ \t]*%.*\r?\n', '', content, flags=re.MULTILINE)
     # Remove all content which follows a % except if % is preceded by \
     return re.sub(r'(?<!\\)%.*', '', content)

--- a/setup.py
+++ b/setup.py
@@ -26,4 +26,5 @@ setup(
     include_package_data = True,
     install_requires = requires,
     entry_points = entry_points,
+    test_suite = "test"
 )

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,25 @@
+import unittest
+from rcs_latexdiff import utils
+
+contentWithComments = """
+Lorem ipsum 1
+% lorem ipsum 2
+lorem ipsum 3 % lorem ipsum
+\% lorem ipsum 4
+lorem ipsum 5
+"""
+
+contentWithoutComments = """
+Lorem ipsum 1
+lorem ipsum 3 
+\% lorem ipsum 4
+lorem ipsum 5
+"""
+
+class TestUtils(unittest.TestCase):
+  def test_remove_latex_comments(self):
+    parsedContent = utils.remove_latex_comments(contentWithComments)
+    self.assertEqual(parsedContent, contentWithoutComments)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This fixes some strange bugs. For example in tikzpictures,
when the newline is not removed with the comment
an empty line is created, which can break the compilation.